### PR TITLE
build: exclude dir or file

### DIFF
--- a/.github/workflows/line_lint.yml
+++ b/.github/workflows/line_lint.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo build --release
       - run: mv target/release/linelint cli
-      - run: ./cli check
+      - run: ./cli check --exclude ${{ inputs.exclude || '' }}

--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ Ensures files end with a newline (`\n`).
 Flags trailing spaces at the end of lines.
 
 **Fix:** Remove trailing spaces.
+
+## Cli Usage Example(exclude dir or file) 
+```bash
+./cli check --exclude 'linelint/src,linelint-cli/src/main.rs'
+
+./cli format --exclude 'linelint/src,linelint-cli/src/main.rs'
+
+./cli check -e 'linelint/src/rule,linelint-cli'
+
+./cli format -e 'linelint/src/rule,linelint-cli'
+```

--- a/linelint-cli/src/main.rs
+++ b/linelint-cli/src/main.rs
@@ -1,13 +1,13 @@
-use clap::Command;
+use clap::{Arg, Command};
 use linelint::config::Config;
 use linelint::line::LineEnding;
 use linelint::linter::Linter;
 use linelint::rule::line_end_lint::LineEndLint;
 use linelint::rule::trailing_ws_lint::TrailingWhitespaceLint;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-fn check(current_dir: &Path, linter: &Linter) {
-    match linter.check_files_in_dir(current_dir) {
+fn check(current_dir: &Path, exclude_paths: Vec<PathBuf>, linter: &Linter) {
+    match linter.check_files_in_dir(current_dir, exclude_paths) {
         Ok(issues) => {
             if issues.is_empty() {
                 println!("No issues found.");
@@ -29,8 +29,8 @@ fn check(current_dir: &Path, linter: &Linter) {
     }
 }
 
-fn format(current_dir: &Path, linter: &Linter) {
-    match linter.format_files_in_dir(current_dir) {
+fn format(current_dir: &Path, exclude_paths: Vec<PathBuf>, linter: &Linter) {
+    match linter.format_files_in_dir(current_dir, exclude_paths) {
         Ok(_) => println!("Files formatted successfully."),
         Err(errors) => {
             for e in errors {
@@ -44,8 +44,26 @@ fn main() {
     let matches = Command::new("linelint-cli")
         .version("0.0.2")
         .about("A command-line tool for linting and fixing line formatting issues")
-        .subcommand(Command::new("check").about("Check files for lint issues"))
-        .subcommand(Command::new("format").about("Automatically format files to fix lint issues"))
+        .subcommand(
+            Command::new("check")
+                .about("Check files for lint issues")
+                .arg(
+                    Arg::new("exclude")
+                        .long("exclude")
+                        .short('e')
+                        .help("Exclude files or directories for check"),
+                ),
+        )
+        .subcommand(
+            Command::new("format")
+                .about("Automatically format files to fix lint issues")
+                .arg(
+                    Arg::new("exclude")
+                        .long("exclude")
+                        .short('e')
+                        .help("Exclude files or directories for check"),
+                ),
+        )
         .get_matches();
 
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
@@ -58,10 +76,22 @@ fn main() {
 
     if matches.subcommand().is_none() {
         println!("No subcommand provided, defaulting to 'check'...");
-        check(&current_dir, &linter);
-    } else if matches.subcommand_matches("check").is_some() {
-        check(&current_dir, &linter);
-    } else if matches.subcommand_matches("format").is_some() {
-        format(&current_dir, &linter);
+        check(&current_dir, vec![], &linter);
+    } else if let Some(check_match) = matches.subcommand_matches("check") {
+        let ex = check_match.get_one::<String>("exclude");
+        let exclude_paths: Vec<PathBuf> = if let Some(ex) = ex {
+            ex.split(',').map(|s| current_dir.join(s)).collect()
+        } else {
+            vec![]
+        };
+        check(&current_dir, exclude_paths, &linter);
+    } else if let Some(format_match) = matches.subcommand_matches("format") {
+        let ex = format_match.get_one::<String>("exclude");
+        let exclude_paths: Vec<PathBuf> = if let Some(ex) = ex {
+            ex.split(',').map(|s| current_dir.join(s)).collect()
+        } else {
+            vec![]
+        };
+        format(&current_dir, exclude_paths, &linter);
     }
 }

--- a/linelint/src/linter.rs
+++ b/linelint/src/linter.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::issue::Issue;
 use crate::line::LineEnding;
 use ignore::WalkBuilder;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 pub struct Linter<'a> {
@@ -17,10 +17,11 @@ impl<'a> Linter<'a> {
     pub fn check_files_in_dir(
         &self,
         dir: &Path,
+        exclude_paths: Vec<PathBuf>,
     ) -> Result<Vec<Issue>, Vec<(std::path::PathBuf, io::Error)>> {
         let mut all_issues = Vec::new();
 
-        let result = self.travel_dir(dir, |path| match fs::read_to_string(path) {
+        let result = self.travel_dir(dir, exclude_paths, |path| match fs::read_to_string(path) {
             Ok(content) => {
                 let issues = self.check(path.to_str().unwrap(), &content);
                 all_issues.extend(issues);
@@ -35,8 +36,9 @@ impl<'a> Linter<'a> {
     pub fn format_files_in_dir(
         &self,
         dir: &Path,
+        exclude_paths: Vec<PathBuf>,
     ) -> Result<(), Vec<(std::path::PathBuf, io::Error)>> {
-        self.travel_dir(dir, |path| match fs::read_to_string(path) {
+        self.travel_dir(dir, exclude_paths, |path| match fs::read_to_string(path) {
             Ok(content) => {
                 let formatted_content = self.format(&content);
                 if formatted_content != content {
@@ -52,6 +54,7 @@ impl<'a> Linter<'a> {
     fn travel_dir<F>(
         &self,
         dir: &Path,
+        exclude_paths: Vec<PathBuf>,
         mut file_handler: F,
     ) -> Result<(), Vec<(std::path::PathBuf, io::Error)>>
     where
@@ -73,6 +76,15 @@ impl<'a> Linter<'a> {
         for entry in walker {
             match entry {
                 Ok(entry) => {
+                    let path = entry.path();
+
+                    if exclude_paths
+                        .iter()
+                        .any(|ex| path.starts_with(ex.as_path()))
+                    {
+                        continue;
+                    }
+
                     if entry
                         .path()
                         .components()
@@ -103,7 +115,7 @@ impl<'a> Linter<'a> {
                     } else {
                         continue;
                     }
-
+                    
                     if entry.file_type().map_or(false, |ft| ft.is_file()) {
                         if let Err(e) = file_handler(entry.path()) {
                             errors.push((entry.path().to_path_buf(), e));


### PR DESCRIPTION
Lint cli add arg --exclude "DIR_PATH,FILE_PATH..." 
will exclude dir or file when check or format